### PR TITLE
[#1] 메인 페이지 Card 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,13 @@
         "ts": "never",
         "tsx": "never"
       }
-    ]
+    ],
+    "class-methods-use-this": "off",
+    "implicit-arrow-linebreak": "off",
+    "comma-dangle": "off",
+    "no-undef": "off",
+    "object-curly-newline": "off",
+    "operator-linebreak": "off"
   },
   "settings": {
     "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-import-resolver-typescript": "^2.7.1",
         "eslint-plugin-import": "^2.26.0",
+        "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.5.0",
         "style-loader": "^3.3.1",
         "ts-loader": "^9.3.0",
@@ -1047,6 +1048,15 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1724,6 +1734,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
       "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
       "dev": true
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -2489,6 +2508,26 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -3538,6 +3577,32 @@
       "dev": true,
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/locate-path": {
@@ -6664,6 +6729,12 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -7174,6 +7245,12 @@
       "version": "1.4.129",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
       "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
     "encodeurl": {
@@ -7780,6 +7857,16 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
       }
     },
     "fill-range": {
@@ -8527,6 +8614,25 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true
+    },
+    "loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        }
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
+    "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "style-loader": "^3.3.1",
     "ts-loader": "^9.3.0",

--- a/public/image/heart.svg
+++ b/public/image/heart.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M18 1l-6 4-6-4-6 5v7l12 10 12-10v-7z"></path></svg>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>pelog</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/style/reset.css
+++ b/public/style/reset.css
@@ -1,0 +1,124 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/src/component/Card/index.css
+++ b/src/component/Card/index.css
@@ -1,0 +1,41 @@
+.card {
+  box-shadow: rgb(0 0 0 / 4%) 0px 4px 16px 0px;
+  width: 320px;
+}
+.card a {
+  text-decoration: none;
+}
+.image-wrapper {
+  height: 150px;
+  background-color: aqua;
+}
+.card-contents {
+  padding: 15px;
+}
+.card-title {
+  font-weight: bold;
+  font-size: 16px;
+  margin: 0 0 10px 0;
+}
+.card-summary {
+  font-size: 14px;
+  height: 70px;
+}
+.card-date {
+  font-size: 10px;
+  color: gray;
+}
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  border-top: 1px solid #f1f1f1;
+  font-size: 10px;
+}
+.card-writer-info {
+  color: gray;
+}
+.card-writer-info > span {
+  font-weight: bold;
+  color: black;
+}

--- a/src/component/Card/index.ts
+++ b/src/component/Card/index.ts
@@ -1,0 +1,40 @@
+import Component from "core/Component";
+import heart from "../../../public/image/heart.svg";
+import "./index.css";
+
+export default class Card extends Component {
+  template() {
+    const { link, imgSrc, title, summary, date, comments, writer, hearts } =
+      this.props;
+    return `
+      <div class='card'>
+        <a href=${link}>
+          <div class='image-wrapper'>
+            <img src='${imgSrc}' />
+          </div>
+        </a>
+        <div class='card-contents'>
+          <a href=${link}>
+            <p class='card-title'>
+              ${title}
+            </p>
+            <p class='card-summary'>
+              ${summary}
+            </p>
+          </a>
+          <p class='card-date'>${date} · ${comments}개의 댓글</p>
+        </div>
+        <div class='card-footer'>
+          <a class='card-writer-info'>
+            by
+            <span>${writer}</span>
+          </a>
+          <div class='card-heart'>
+            <img src='${heart}'/>
+            <span>${hearts}<span/>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/type/custom.d.ts
+++ b/src/type/custom.d.ts
@@ -1,0 +1,1 @@
+declare module "*.svg";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,15 @@
     "module": "es6",
     "target": "es6",
     "jsx": "react",
+    "lib": ["es2018", "dom", "dom.iterable"],
     "allowJs": true,
-    "moduleResolution": "node"
-  
-  }
+    "moduleResolution": "node",
+    "baseUrl": "src/",
+    "paths": {
+      "*": ["_packages/*", "*"]
+    },
+    "typeRoots": ["src/type"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       title: "Output Management",
-      template: "src/index.html",
+      template: "public/index.html",
     }),
   ],
   module: {
@@ -29,6 +29,7 @@ module.exports = {
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        loader: "file-loader",
         type: "asset/resource",
       },
       {
@@ -39,10 +40,11 @@ module.exports = {
   },
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
+    modules: [path.resolve(__dirname, "src"), "node_modules"],
   },
   devServer: {
     static: {
-      directory: path.join(__dirname, "dist"),
+      directory: path.join(__dirname, "public"),
     },
     open: true,
     port: "auto",


### PR DESCRIPTION
### 변경 및 추가 사항

- 메인 페이지에 보여지는 글 목록을 나타내는 Card 컴포넌트를 구현함.
- Card 컴포넌트만 구현되었기 때문에 Card가 올려질 위치 Template은 구현되지 않음.
- link, imgSrc, title, summary, date, comments, writer, hearts props를 전달 받아 Card에 표시함.

### 생각되는 문제점

- Props가 너무 많음. => 사용할 때 전달하는 Props 가 길어져 가독성이 떨어질 수 있다.
- heart 이미지 추가에 실패함. => 브라우저에도 이미지가 나타나지 않음.

### 결과물

![image](https://user-images.githubusercontent.com/49841765/167134333-bc9cc743-78ef-4510-b1d9-f37c91cec72b.png)
